### PR TITLE
Add Qwen3-ASR-1.7B support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,16 +84,16 @@ jobs:
         if: runner.os == 'macOS'
         run: echo "DYLD_LIBRARY_PATH=${{ github.workspace }}/libtorch/lib:$DYLD_LIBRARY_PATH" >> "$GITHUB_ENV"
 
-      - name: Cache model weights
+      - name: Cache 0.6B model weights
         uses: actions/cache@v4
         with:
           path: Qwen3-ASR-0.6B
           key: qwen3-asr-0.6b-v1
 
-      - name: Download model
+      - name: Download 0.6B model
         run: python3 -c "from huggingface_hub import snapshot_download; snapshot_download('Qwen/Qwen3-ASR-0.6B', local_dir='Qwen3-ASR-0.6B')"
 
-      - name: Generate tokenizer.json
+      - name: Generate 0.6B tokenizer.json
         run: |
           python3 -c "
           from transformers import AutoTokenizer
@@ -102,20 +102,41 @@ jobs:
           print('Saved tokenizer.json')
           "
 
-      - name: Transcribe sample1 (English)
-        run: |
-          echo "=== Sample 1 (English) ==="
-          ./target/release/asr Qwen3-ASR-0.6B test_audio/sample1.wav
+      - name: "[0.6B] Transcribe sample1 (English)"
+        run: ./target/release/asr Qwen3-ASR-0.6B test_audio/sample1.wav
 
-      - name: Transcribe sample2 (English)
-        run: |
-          echo "=== Sample 2 (English) ==="
-          ./target/release/asr Qwen3-ASR-0.6B test_audio/sample2.wav
+      - name: "[0.6B] Transcribe sample2 (English)"
+        run: ./target/release/asr Qwen3-ASR-0.6B test_audio/sample2.wav
 
-      - name: Transcribe sample3 (Chinese)
+      - name: "[0.6B] Transcribe sample3 (Chinese)"
+        run: ./target/release/asr Qwen3-ASR-0.6B test_audio/sample3.wav
+
+      - name: Cache 1.7B model weights
+        uses: actions/cache@v4
+        with:
+          path: Qwen3-ASR-1.7B
+          key: qwen3-asr-1.7b-v1
+
+      - name: Download 1.7B model
+        run: python3 -c "from huggingface_hub import snapshot_download; snapshot_download('Qwen/Qwen3-ASR-1.7B', local_dir='Qwen3-ASR-1.7B')"
+
+      - name: Generate 1.7B tokenizer.json
         run: |
-          echo "=== Sample 3 (Chinese) ==="
-          ./target/release/asr Qwen3-ASR-0.6B test_audio/sample3.wav
+          python3 -c "
+          from transformers import AutoTokenizer
+          tok = AutoTokenizer.from_pretrained('Qwen3-ASR-1.7B', trust_remote_code=True)
+          tok.backend_tokenizer.save('Qwen3-ASR-1.7B/tokenizer.json')
+          print('Saved tokenizer.json')
+          "
+
+      - name: "[1.7B] Transcribe sample1 (English)"
+        run: ./target/release/asr Qwen3-ASR-1.7B test_audio/sample1.wav
+
+      - name: "[1.7B] Transcribe sample2 (English)"
+        run: ./target/release/asr Qwen3-ASR-1.7B test_audio/sample2.wav
+
+      - name: "[1.7B] Transcribe sample3 (Chinese)"
+        run: ./target/release/asr Qwen3-ASR-1.7B test_audio/sample3.wav
 
       - name: Upload binary
         uses: actions/upload-artifact@v4

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ The implementation ports the Qwen3-ASR encoder-decoder architecture from PyTorch
 | Model | Parameters | HuggingFace |
 |-------|-----------|-------------|
 | Qwen3-ASR-0.6B | 0.6B | [Qwen/Qwen3-ASR-0.6B](https://huggingface.co/Qwen/Qwen3-ASR-0.6B) |
+| Qwen3-ASR-1.7B | 1.7B | [Qwen/Qwen3-ASR-1.7B](https://huggingface.co/Qwen/Qwen3-ASR-1.7B) |
 
 ## Prerequisites
 
@@ -54,16 +55,14 @@ sudo apt-get install libavcodec-dev libavformat-dev libavutil-dev libswresample-
 
 ### Model Weights
 
-Download the model from HuggingFace:
+Download a model from HuggingFace:
 
 ```bash
-# Using git-lfs
-git lfs install
-git clone https://huggingface.co/Qwen/Qwen3-ASR-0.6B
-
-# Or using huggingface-cli
-pip install huggingface_hub
+# 0.6B model
 huggingface-cli download Qwen/Qwen3-ASR-0.6B --local-dir Qwen3-ASR-0.6B
+
+# 1.7B model (sharded safetensors, auto-detected)
+huggingface-cli download Qwen/Qwen3-ASR-1.7B --local-dir Qwen3-ASR-1.7B
 ```
 
 Generate `tokenizer.json` (required):

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -34,11 +34,9 @@ impl AsrInference {
         let config =
             AsrConfig::from_file(&model_dir.join("config.json")).context("Failed to load config")?;
 
-        // Load weights
-        let safetensors_path = model_dir.join("model.safetensors");
-        tracing::info!("Loading weights from {:?}", safetensors_path);
+        // Load weights (supports both single-file and sharded safetensors)
         let all_weights =
-            weights::load_safetensors(&safetensors_path, device).context("Failed to load weights")?;
+            weights::load_model_weights(model_dir, device).context("Failed to load weights")?;
 
         tracing::info!("Loaded {} weight tensors", all_weights.len());
 


### PR DESCRIPTION
## Summary
- Support sharded safetensors loading (auto-detects `model.safetensors.index.json` + multiple shard files alongside single-file format)
- Add Qwen3-ASR-1.7B to supported models in README
- Add 1.7B model testing to CI workflow (all 3 test audio samples)

## Test plan
- [x] 0.6B model still works (all 3 samples correct)
- [x] 1.7B model works (all 3 samples correct)
- [ ] CI passes on all 3 platforms (Linux x86_64, Linux ARM64, macOS ARM64)

🤖 Generated with [Claude Code](https://claude.com/claude-code)