### PR TITLE
Add Claude Code skills for voice transcription

### DIFF
--- a/skills/SKILL.md
+++ b/skills/SKILL.md
@@ -1,0 +1,113 @@
+# Qwen3 ASR — Voice Transcription
+
+Transcribe speech from audio files to text.
+
+## Binary
+
+- `{baseDir}/scripts/asr` — Speech-to-text transcription.
+
+## Models
+
+- `{baseDir}/scripts/models/Qwen3-ASR-0.6B` — Faster, lighter model (0.6B parameters).
+- `{baseDir}/scripts/models/Qwen3-ASR-1.7B` — Higher accuracy model (1.7B parameters).
+
+## Environment Setup
+
+On Linux, set `LD_LIBRARY_PATH` before running:
+
+```shell
+export LD_LIBRARY_PATH={baseDir}/scripts/libtorch/lib:$LD_LIBRARY_PATH
+```
+
+On macOS, set `DYLD_LIBRARY_PATH` before running:
+
+```shell
+export DYLD_LIBRARY_PATH={baseDir}/scripts/libtorch/lib:$DYLD_LIBRARY_PATH
+```
+
+## Transcription
+
+Transcribe an audio file to text.
+
+```shell
+# Linux
+LD_LIBRARY_PATH={baseDir}/scripts/libtorch/lib:$LD_LIBRARY_PATH \
+  {baseDir}/scripts/asr \
+  {baseDir}/scripts/models/Qwen3-ASR-0.6B \
+  <audio_file>
+
+# macOS
+DYLD_LIBRARY_PATH={baseDir}/scripts/libtorch/lib:$DYLD_LIBRARY_PATH \
+  {baseDir}/scripts/asr \
+  {baseDir}/scripts/models/Qwen3-ASR-0.6B \
+  <audio_file>
+```
+
+### Parameters
+
+| Parameter  | Required | Description                                        |
+|------------|----------|----------------------------------------------------|
+| model_path | Yes      | Path to the model directory (0.6B or 1.7B)         |
+| audio_file | Yes      | Path to the audio file (any FFmpeg-supported format)|
+
+### Output
+
+Prints the transcribed text to standard output.
+
+### Example
+
+```shell
+# Linux
+LD_LIBRARY_PATH={baseDir}/scripts/libtorch/lib:$LD_LIBRARY_PATH \
+  {baseDir}/scripts/asr \
+  {baseDir}/scripts/models/Qwen3-ASR-0.6B \
+  recording.wav
+
+# macOS
+DYLD_LIBRARY_PATH={baseDir}/scripts/libtorch/lib:$DYLD_LIBRARY_PATH \
+  {baseDir}/scripts/asr \
+  {baseDir}/scripts/models/Qwen3-ASR-0.6B \
+  recording.wav
+```
+
+## Model Selection
+
+- Use **0.6B** for fast transcription where speed matters more than accuracy.
+- Use **1.7B** for higher accuracy, especially on difficult audio, accents, or low-quality recordings.
+
+## Supported Audio Formats
+
+Any format supported by FFmpeg: WAV, MP3, M4A, FLAC, OGG, and more. Audio is automatically resampled to 16 kHz mono internally.
+
+## Workflow
+
+### 1. Identify the Audio File
+
+Get the path to the audio file the user wants to transcribe.
+
+### 2. Choose a Model
+
+- Default to **0.6B** unless the user asks for higher accuracy or the 0.6B result is unsatisfactory.
+- Switch to **1.7B** when the user requests it, or when the audio is noisy, heavily accented, or the 0.6B output looks wrong.
+
+### 3. Run the Command
+
+Run the `asr` binary with the library path set. Use the full paths to the binary and model directory.
+
+```shell
+# Linux
+LD_LIBRARY_PATH={baseDir}/scripts/libtorch/lib:$LD_LIBRARY_PATH \
+  {baseDir}/scripts/asr \
+  {baseDir}/scripts/models/Qwen3-ASR-0.6B \
+  /path/to/audio.mp3
+
+# macOS
+DYLD_LIBRARY_PATH={baseDir}/scripts/libtorch/lib:$DYLD_LIBRARY_PATH \
+  {baseDir}/scripts/asr \
+  {baseDir}/scripts/models/Qwen3-ASR-0.6B \
+  /path/to/audio.mp3
+```
+
+### 4. Return the Transcription
+
+The transcribed text is printed to stdout. Return it to the user.

--- a/skills/bootstrap.sh
+++ b/skills/bootstrap.sh
@@ -1,0 +1,182 @@
+#!/bin/bash
+# Bootstrap script for Qwen3 ASR skill
+# Downloads platform-specific binary, libtorch, and models
+
+set -e
+
+REPO="second-state/qwen3_asr_rs"
+SKILL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="${SKILL_DIR}/scripts"
+MODELS_DIR="${SCRIPTS_DIR}/models"
+
+detect_platform() {
+    local os arch
+
+    case "$(uname -s)" in
+    Linux*) os="linux" ;;
+    Darwin*) os="darwin" ;;
+    *)
+        echo "Error: Unsupported operating system: $(uname -s)" >&2
+        exit 1
+        ;;
+    esac
+
+    case "$(uname -m)" in
+    x86_64 | amd64) arch="x86_64" ;;
+    aarch64 | arm64) arch="aarch64" ;;
+    *)
+        echo "Error: Unsupported architecture: $(uname -m)" >&2
+        exit 1
+        ;;
+    esac
+
+    echo "${os}-${arch}"
+}
+
+get_asset_name() {
+    local platform="$1"
+
+    case "$platform" in
+    linux-x86_64)
+        echo "asr-linux-x86_64"
+        ;;
+    linux-aarch64)
+        echo "asr-linux-aarch64"
+        ;;
+    darwin-aarch64)
+        echo "asr-macos-aarch64"
+        ;;
+    *)
+        echo "Error: Unsupported platform: ${platform}" >&2
+        exit 1
+        ;;
+    esac
+}
+
+download_binary() {
+    local asset_name="$1"
+
+    echo "=== Downloading binary (${asset_name}) ===" >&2
+
+    mkdir -p "${SCRIPTS_DIR}"
+
+    # Get download URL from latest release
+    local api_url="https://api.github.com/repos/${REPO}/releases/latest"
+    local download_url
+    download_url=$(curl -sL "$api_url" | grep -o "https://github.com/${REPO}/releases/download/[^\"]*/${asset_name}" | head -1)
+
+    if [ -z "$download_url" ]; then
+        echo "Error: Could not find release asset ${asset_name}" >&2
+        echo "Check https://github.com/${REPO}/releases for available downloads." >&2
+        exit 1
+    fi
+
+    echo "Fetching from: ${download_url}" >&2
+    curl -sL -o "${SCRIPTS_DIR}/asr" "$download_url"
+    chmod +x "${SCRIPTS_DIR}/asr"
+
+    echo "Binary installed to ${SCRIPTS_DIR}/asr" >&2
+}
+
+download_libtorch() {
+    local platform="$1"
+
+    echo "=== Downloading libtorch ===" >&2
+
+    local libtorch_url=""
+    local archive_name=""
+
+    case "$platform" in
+    linux-x86_64)
+        libtorch_url="https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-2.7.1%2Bcpu.zip"
+        archive_name="libtorch.zip"
+        ;;
+    linux-aarch64)
+        libtorch_url="https://github.com/second-state/libtorch-releases/releases/download/v2.7.1/libtorch-cxx11-abi-aarch64-2.7.1.tar.gz"
+        archive_name="libtorch.tar.gz"
+        ;;
+    darwin-aarch64)
+        libtorch_url="https://download.pytorch.org/libtorch/cpu/libtorch-macos-arm64-2.7.1.zip"
+        archive_name="libtorch.zip"
+        ;;
+    *)
+        echo "Error: No libtorch URL for platform ${platform}" >&2
+        exit 1
+        ;;
+    esac
+
+    local temp_dir
+    temp_dir=$(mktemp -d)
+
+    echo "Fetching from: ${libtorch_url}" >&2
+    curl -sL -o "${temp_dir}/${archive_name}" "$libtorch_url"
+
+    echo "Extracting libtorch..." >&2
+    if [[ "$archive_name" == *.zip ]]; then
+        unzip -q "${temp_dir}/${archive_name}" -d "${temp_dir}"
+    else
+        tar xzf "${temp_dir}/${archive_name}" -C "${temp_dir}"
+    fi
+
+    rm -rf "${SCRIPTS_DIR}/libtorch"
+    mv "${temp_dir}/libtorch" "${SCRIPTS_DIR}/libtorch"
+
+    rm -rf "$temp_dir"
+    echo "libtorch installed to ${SCRIPTS_DIR}/libtorch" >&2
+}
+
+download_models() {
+    echo "=== Downloading models ===" >&2
+
+    mkdir -p "${MODELS_DIR}"
+
+    # Ensure huggingface_hub and transformers are available
+    if ! command -v huggingface-cli &>/dev/null; then
+        echo "Installing huggingface_hub and transformers..." >&2
+        pip install -q huggingface_hub transformers
+    fi
+
+    for model in Qwen3-ASR-0.6B Qwen3-ASR-1.7B; do
+        local model_dir="${MODELS_DIR}/${model}"
+        if [ ! -d "$model_dir" ] || [ -z "$(ls -A "$model_dir" 2>/dev/null)" ]; then
+            echo "Downloading ${model}..." >&2
+            huggingface-cli download "Qwen/${model}" --local-dir "$model_dir"
+        else
+            echo "${model} already downloaded, skipping." >&2
+        fi
+    done
+
+    # Generate tokenizer.json files
+    echo "Generating tokenizer.json files..." >&2
+    python3 -c "
+from transformers import AutoTokenizer
+for model in ['Qwen3-ASR-0.6B', 'Qwen3-ASR-1.7B']:
+    path = '${MODELS_DIR}/' + model
+    tok = AutoTokenizer.from_pretrained(path, trust_remote_code=True)
+    tok.backend_tokenizer.save(path + '/tokenizer.json')
+    print(f'Saved {path}/tokenizer.json')
+"
+
+    echo "Models installed to ${MODELS_DIR}" >&2
+}
+
+main() {
+    local platform
+    platform=$(detect_platform)
+    echo "Detected platform: ${platform}" >&2
+
+    local asset_name
+    asset_name=$(get_asset_name "$platform")
+    echo "Asset: ${asset_name}" >&2
+
+    download_binary "$asset_name"
+    download_libtorch "$platform"
+    download_models
+
+    echo "" >&2
+    echo "=== Installation complete ===" >&2
+    echo "Installed files:" >&2
+    ls -1 "${SCRIPTS_DIR}" | grep -v '^\.' >&2
+}
+
+main "$@"

--- a/skills/install.md
+++ b/skills/install.md
@@ -1,0 +1,110 @@
+# Qwen3 ASR Skill — Installation Guide
+
+Install the Qwen3 ASR skill for voice transcription using Qwen3-ASR-0.6B and Qwen3-ASR-1.7B.
+
+## Prerequisites
+
+- `curl` (for downloading)
+- `unzip` and `tar` (for extraction)
+- `bash` (shell)
+- `pip` with `huggingface_hub` and `transformers` (for model download and tokenizer generation)
+
+## Quick Install (Recommended)
+
+```bash
+SKILL_DIR="${HOME}/.openclaw/skills/audio_asr"
+mkdir -p "$SKILL_DIR"
+
+# Clone the repo
+git clone --depth 1 https://github.com/second-state/qwen3_asr_rs.git /tmp/qwen3-asr-repo
+cp -r /tmp/qwen3-asr-repo/skills/* "$SKILL_DIR"
+rm -rf /tmp/qwen3-asr-repo
+
+# Download platform-specific binary, libtorch, and models
+"${SKILL_DIR}/bootstrap.sh"
+```
+
+After installation, verify it works:
+
+```bash
+# Linux
+LD_LIBRARY_PATH=~/.openclaw/skills/audio_asr/scripts/libtorch/lib:$LD_LIBRARY_PATH \
+  ~/.openclaw/skills/audio_asr/scripts/asr \
+  ~/.openclaw/skills/audio_asr/scripts/models/Qwen3-ASR-0.6B \
+  /path/to/audio.wav
+
+# macOS
+DYLD_LIBRARY_PATH=~/.openclaw/skills/audio_asr/scripts/libtorch/lib:$DYLD_LIBRARY_PATH \
+  ~/.openclaw/skills/audio_asr/scripts/asr \
+  ~/.openclaw/skills/audio_asr/scripts/models/Qwen3-ASR-0.6B \
+  /path/to/audio.wav
+```
+
+## Manual Installation
+
+If the automatic download fails, manually install the components:
+
+1. Go to https://github.com/second-state/qwen3_asr_rs/releases/latest
+2. Download the binary for your platform:
+   - `asr-linux-x86_64` (Linux x86_64)
+   - `asr-linux-aarch64` (Linux ARM64)
+   - `asr-macos-aarch64` (macOS Apple Silicon)
+3. Copy to `~/.openclaw/skills/audio_asr/scripts/asr` and make it executable:
+   ```bash
+   mkdir -p ~/.openclaw/skills/audio_asr/scripts
+   cp asr-<platform> ~/.openclaw/skills/audio_asr/scripts/asr
+   chmod +x ~/.openclaw/skills/audio_asr/scripts/asr
+   ```
+4. Download libtorch and extract to `~/.openclaw/skills/audio_asr/scripts/libtorch/`:
+   - Linux x86_64: https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-2.7.1%2Bcpu.zip
+   - Linux aarch64: https://github.com/second-state/libtorch-releases/releases/download/v2.7.1/libtorch-cxx11-abi-aarch64-2.7.1.tar.gz
+   - macOS arm64: https://download.pytorch.org/libtorch/cpu/libtorch-macos-arm64-2.7.1.zip
+5. Download models:
+   ```bash
+   huggingface-cli download Qwen/Qwen3-ASR-0.6B \
+     --local-dir ~/.openclaw/skills/audio_asr/scripts/models/Qwen3-ASR-0.6B
+   huggingface-cli download Qwen/Qwen3-ASR-1.7B \
+     --local-dir ~/.openclaw/skills/audio_asr/scripts/models/Qwen3-ASR-1.7B
+   ```
+6. Generate `tokenizer.json` for each model:
+   ```bash
+   python3 -c "
+   from transformers import AutoTokenizer
+   import os
+   base = os.path.expanduser('~/.openclaw/skills/audio_asr/scripts/models')
+   for model in ['Qwen3-ASR-0.6B', 'Qwen3-ASR-1.7B']:
+       path = f'{base}/{model}'
+       tok = AutoTokenizer.from_pretrained(path, trust_remote_code=True)
+       tok.backend_tokenizer.save(f'{path}/tokenizer.json')
+       print(f'Saved {path}/tokenizer.json')
+   "
+   ```
+
+## Troubleshooting
+
+### Download Failed
+
+Check network connectivity:
+
+```bash
+curl -I "https://github.com/second-state/qwen3_asr_rs/releases/latest"
+```
+
+### Unsupported Platform
+
+Check your platform:
+
+```bash
+echo "OS: $(uname -s), Arch: $(uname -m)"
+```
+
+Supported: Linux (x86_64, aarch64) and macOS (Apple Silicon arm64).
+
+### Missing libtorch
+
+Ensure the library path includes the libtorch lib directory:
+
+- Linux: `export LD_LIBRARY_PATH=~/.openclaw/skills/audio_asr/scripts/libtorch/lib:$LD_LIBRARY_PATH`
+- macOS: `export DYLD_LIBRARY_PATH=~/.openclaw/skills/audio_asr/scripts/libtorch/lib:$DYLD_LIBRARY_PATH`
+
+The SKILL.md instructions set this automatically when running commands.


### PR DESCRIPTION
## Summary

- Adds `skills/` directory with SKILL.md, install.md, and bootstrap.sh
- Enables Qwen3-ASR as a Claude Code skill for speech-to-text transcription
- bootstrap.sh auto-detects platform and downloads binary, libtorch, and models

## Test plan

- [ ] Verify `bootstrap.sh` runs on macOS Apple Silicon
- [ ] Verify `bootstrap.sh` runs on Linux x86_64
- [ ] Verify transcription works after bootstrap completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)