### PR TITLE
Fix where_self argument order in attention mask construction

### DIFF
--- a/src/audio_encoder.rs
+++ b/src/audio_encoder.rs
@@ -236,7 +236,7 @@ impl AudioEncoder {
             );
             // where(allow, 0, -inf)
             let mask = Tensor::from_tch(
-                allow_mask.as_tch().where_self(&zero.into_tch(), &neg_inf.into_tch())
+                zero.into_tch().where_self(&allow_mask.as_tch(), &neg_inf.into_tch())
             );
             Some(mask)
         }


### PR DESCRIPTION
## Summary

- Fixes incorrect argument order in `where_self` call in `src/audio_encoder.rs` (line 239)
- `tch::Tensor::where_self(condition, other)` wraps `torch.where(condition, self, other)` where `condition` must be a Bool tensor
- The previous code passed `allow_mask` (Bool) as `self` and `zero` (Float) as `condition`, swapping the roles of condition and value
- The fix makes `zero` the receiver (`self`), `allow_mask` the condition, and `neg_inf` the fallback value, matching the comment `// where(allow, 0, -inf)`

### Before (incorrect)
```rust
allow_mask.as_tch().where_self(&zero.into_tch(), &neg_inf.into_tch())
```

### After (correct)
```rust
zero.into_tch().where_self(&allow_mask.as_tch(), &neg_inf.into_tch())
```

## Test plan

- [ ] Verify the attention mask produces 0 where tokens are allowed and -inf where they are masked
- [ ] Run existing tests to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)