### PR TITLE
Fix MSVC CRT mismatch from tokenizers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -576,9 +576,6 @@ name = "esaxx-rs"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d817e038c30374a4bcb22f94d0a8a0e216958d4c3dcde369b1439fec4bdda6e6"
-dependencies = [
- "cc",
-]
 
 [[package]]
 name = "extended"
@@ -1264,7 +1261,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "qwen3_asr"
+name = "qwen3-asr-rs"
 version = "0.2.0"
 dependencies = [
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,9 @@ path = "src/bin/server.rs"
 
 [dependencies]
 tch = { version = "0.20", optional = true }
-tokenizers = "0.21"
+# Keep tokenizers' default capabilities except esaxx_fast: esaxx-rs/cpp
+# hardcodes MSVC /MT, which conflicts with libtorch/tch's dynamic CRT on Windows.
+tokenizers = { version = "0.21", default-features = false, features = ["onig", "progressbar"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 hound = "3.5"


### PR DESCRIPTION
Fix the Windows MSVC build by disabling `tokenizers`' `esaxx_fast` feature.

`esaxx_fast` enables `esaxx-rs/cpp`, which builds C++ code with `/MT`. This conflicts with libtorch/tch's `/MD` CRT linkage on Windows and causes LNK2038/LNK1169 linker errors.

This crate only loads `tokenizer.json` and uses encode/decode during inference, so the tokenizer training accelerator is not needed. This should not affect inference builds on other platforms.